### PR TITLE
Update utils.py TopologicalError

### DIFF
--- a/gpd_lite_toolbox/utils.py
+++ b/gpd_lite_toolbox/utils.py
@@ -12,7 +12,7 @@ import pandas as pd
 import geopandas as gpd
 from sklearn.preprocessing import normalize
 from sklearn.metrics.pairwise import pairwise_distances
-from shapely.geos import TopologicalError
+from shapely.errors import TopologicalError
 
 def nrepeat(iterable, n):
     return iter([i for i in iterable for j in range(n)])


### PR DESCRIPTION
Importing from `shapely.errors` avoids TopologicalError not found error. Closes #6.
